### PR TITLE
Fix: incorrect usage of built-in function

### DIFF
--- a/u.go
+++ b/u.go
@@ -1,7 +1,9 @@
 package main
 
+import "fmt"
+
 func main() {
 	for {
-		print("u")
+		fmt.Print("u")
 	}
 }


### PR DESCRIPTION
print() is a built-in function used for bootstrapping (see this https://golang.org/ref/spec#Bootstrapping), and it's not guaranteed to stay in the language. For production use you should import the package "fmt".